### PR TITLE
Implement a CLI for LondonLife text files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     "prettier.proseWrap": "always",
     "cSpell.words": [
         "ANAG",
+        "Arity",
         "DARC",
         "DENC",
         "Ekona",

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,6 +11,8 @@
         <PackageVersion Include="BenchmarkDotNet" Version="0.12.1" />
         <PackageVersion Include="YamlDotNet" Version="9.1.4" />
 
+        <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />

--- a/src/LayTea.Tool/LayTea.Tool.csproj
+++ b/src/LayTea.Tool/LayTea.Tool.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AssemblyName>LayTeaConsole</AssemblyName>
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>SceneGate.Games.ProfessorLayton.Tool</RootNamespace>
 
@@ -16,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../LayTea/LayTea.csproj" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
 </Project>

--- a/src/LayTea.Tool/LondonLife/CommandLine.cs
+++ b/src/LayTea.Tool/LondonLife/CommandLine.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Games.ProfessorLayton.Tool.LondonLife
+{
+    using System.CommandLine;
+    using System.CommandLine.Invocation;
+
+    /// <summary>
+    /// Command-line interface for Professor Layton London Life game.
+    /// </summary>
+    public static class CommandLine
+    {
+        /// <summary>
+        /// Create the CLI command for the game.
+        /// </summary>
+        /// <returns>The CLI command.</returns>
+        public static Command CreateCommand()
+        {
+            var exportLondonLife = new Command("export-text", "Export the text") {
+                new Option<string>("--input", "the game file", ArgumentArity.ExactlyOne),
+                new Option<LondonLifeTextFormat>("--format", "the format of the input file", ArgumentArity.ExactlyOne),
+                new Option<string>("--output", "the output folder for the text files", ArgumentArity.ExactlyOne),
+            };
+            exportLondonLife.Handler = CommandHandler.Create<string, LondonLifeTextFormat, string>(TextCommands.Export);
+
+            var importLondonLife = new Command("import-text", "Import the text") {
+                new Option<string>("--input", "the input folder with the text files", ArgumentArity.ExactlyOne),
+                new Option<string>("--original-darc", "the original ll_common.darc file if the output format is CommonDarc", ArgumentArity.ZeroOrOne),
+                new Option<string>("--output", "the new game file", ArgumentArity.ExactlyOne),
+                new Option<LondonLifeTextFormat>("--format", "the format of the output file", ArgumentArity.ExactlyOne),
+            };
+            importLondonLife.Handler = CommandHandler.Create<string, string, string, LondonLifeTextFormat>(TextCommands.Import);
+
+            return new Command("londonlife", "Professor Layton London Life (US only)") {
+                exportLondonLife,
+                importLondonLife,
+            };
+        }
+    }
+}

--- a/src/LayTea.Tool/LondonLife/LondonLifeTextFormat.cs
+++ b/src/LayTea.Tool/LondonLife/LondonLifeTextFormat.cs
@@ -1,15 +1,15 @@
-﻿// Copyright (c) 2020 Benito Palacios Sánchez
-//
+// Copyright (c) 2021 SceneGate
+
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-//
+
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-//
+
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -17,25 +17,21 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-namespace SceneGate.Games.ProfessorLayton.Tool
+namespace SceneGate.Games.ProfessorLayton.Tool.LondonLife
 {
-    using System.CommandLine;
-
     /// <summary>
-    /// Main program class.
+    /// Format of the London Life binary text file.
     /// </summary>
-    public static class Program
+    public enum LondonLifeTextFormat
     {
         /// <summary>
-        /// Main entry-point.
+        /// Common DARC container: "ll_common.darc".
         /// </summary>
-        /// <param name="args">Application arguments.</param>
-        /// <returns>The return code.</returns>
-        public static int Main(string[] args)
-        {
-            return new RootCommand("Convert files from Professor Layton games") {
-                LondonLife.CommandLine.CreateCommand(),
-            }.Invoke(args);
-        }
+        CommonDarc,
+
+        /// <summary>
+        /// Binary message file inside DARC container.
+        /// </summary>
+        MessageBinary,
     }
 }

--- a/src/LayTea.Tool/LondonLife/TextCommands.cs
+++ b/src/LayTea.Tool/LondonLife/TextCommands.cs
@@ -1,0 +1,135 @@
+// Copyright (c) 2021 SceneGate
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace SceneGate.Games.ProfessorLayton.Tool.LondonLife
+{
+    using System;
+    using System.IO;
+    using SceneGate.Games.ProfessorLayton.Containers;
+    using SceneGate.Games.ProfessorLayton.Texts;
+    using SceneGate.Games.ProfessorLayton.Texts.LondonLife;
+    using Yarhl.FileSystem;
+    using Yarhl.IO;
+    using Yarhl.Media.Text;
+
+    /// <summary>
+    /// Commands related to text files.
+    /// </summary>
+    public static class TextCommands
+    {
+        /// <summary>
+        /// Export the message file into a directory of PO files.
+        /// </summary>
+        /// <param name="input">The input binary message file.</param>
+        /// <param name="format">The format of the message file.</param>
+        /// <param name="output">The output directory.</param>
+        public static void Export(string input, LondonLifeTextFormat format, string output)
+        {
+            var region = LondonLifeRegion.Usa;
+            using Node node = NodeFactory.FromFile(input, FileOpenMode.Read);
+
+            Node messageNode = null;
+            switch (format) {
+                case LondonLifeTextFormat.CommonDarc:
+                    messageNode = node.TransformWith<BinaryDarc2Container>()
+                        .Children[2]
+                        .TransformWith<DencDecompression>();
+                    break;
+
+                case LondonLifeTextFormat.MessageBinary:
+                    // do nothing as we convert below
+                    messageNode = node;
+                    break;
+
+                default:
+                    throw new NotSupportedException("Unsupported format");
+            }
+
+            messageNode.TransformWith<Binary2MessageCollection>()
+                .TransformWith<MessageCollection2PoContainer, LondonLifeRegion>(region);
+
+            var replacerParams = new PoTableReplacerParams {
+                Replacer = ReplacerFactory.GetReplacer(region),
+                TransformForward = true,
+            };
+            foreach (var children in messageNode.Children) {
+                children.TransformWith<PoTableReplacer, PoTableReplacerParams>(replacerParams)
+                    .TransformWith<Po2Binary>()
+                    .Stream.WriteTo(Path.Combine(output, $"{children.Name}.po"));
+            }
+        }
+
+        /// <summary>
+        /// Import a directory of PO files into a binary message file.
+        /// </summary>
+        /// <param name="input">The input directory of PO files.</param>
+        /// <param name="originalDarc">The path to the original ll_common.darc container when the output format is DARC.</param>
+        /// <param name="output">The new binary message file.</param>
+        /// <param name="format">The format of the output file.</param>
+        /// <returns>A return code of the operation.</returns>
+        public static int Import(string input, string originalDarc, string output, LondonLifeTextFormat format)
+        {
+            if (format == LondonLifeTextFormat.CommonDarc && !File.Exists(originalDarc)) {
+                Console.WriteLine(
+                    $"The format '{nameof(LondonLifeTextFormat.CommonDarc)}' " +
+                    "requires the argument --original-darc");
+                return 1;
+            }
+
+            var region = LondonLifeRegion.Usa;
+            var replacerParams = new PoTableReplacerParams {
+                Replacer = ReplacerFactory.GetReplacer(region),
+                TransformForward = false,
+            };
+
+            using var node = NodeFactory.FromDirectory(input, "*.po", FileOpenMode.Read);
+            foreach (var child in node.Children) {
+                child.TransformWith<Binary2Po>()
+                    .TransformWith<PoTableReplacer, PoTableReplacerParams>(replacerParams);
+            }
+
+            node.TransformWith<PoContainer2MessageCollection>()
+                .TransformWith<MessageCollection2Binary>();
+
+            switch (format) {
+                case LondonLifeTextFormat.CommonDarc:
+                    // Compress message with LZSS in DENC
+                    node.TransformWith<DencCompression, DencCompressionKind>(DencCompressionKind.Lzss);
+
+                    // Open container
+                    var darc = NodeFactory.FromFile(originalDarc, FileOpenMode.Read)
+                        .TransformWith<BinaryDarc2Container>();
+
+                    // Replace and write
+                    darc.Children[2].ChangeFormat(node.Format);
+                    darc.TransformWith<NodeContainer2BinaryDarc>()
+                        .Stream.WriteTo(output);
+                    darc.Dispose();
+                    break;
+
+                case LondonLifeTextFormat.MessageBinary:
+                    // already in binary - just write
+                    node.Stream.WriteTo(output);
+                    break;
+            }
+
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
### Description

New CLI to import and export text files for the London Life game.

### Example

```sh
# Export from ll_common.darc file
LayTeaConsole londonlife export-text --input ll_common.darc --output messages --format CommonDarc

# Export from binary message file
LayTeaConsole londonlife export-text --input msg.bin --output messages --format MessageBinary

# Import into ll_common.darc
LayTeaConsole londonlife import-text --input messages --output new_ll_common.darc --format CommonDarc --original-darc ll_common.darc

# Import into binary message file
LayTeaConsole londonlife import-text --input messages --output new_msg.bin --format MessageBinary
```