### PR TITLE
Support external table for LondonLife and add custom table for EUR translations

### DIFF
--- a/src/LayTea.Tests/Texts/LondonLife/MessageCollection2BinaryTests.cs
+++ b/src/LayTea.Tests/Texts/LondonLife/MessageCollection2BinaryTests.cs
@@ -44,7 +44,9 @@ namespace SceneGate.Games.ProfessorLayton.Tests.Texts.LondonLife
         {
             var expectedCollection = new MessageCollection();
             var expectedMessage = new Message();
-            expectedMessage.Add("ñú");
+            expectedMessage.Add("ñ23" + "aú34" + "ú24");
+            expectedMessage.Add(MessageFunction.FromId(0xF1, null));
+            expectedMessage.Add("ñu");
             expectedCollection.Messages.Add(expectedMessage);
 
             var serializer = new MessageCollection2Binary();

--- a/src/LayTea.Tool/LayTea.Tool.csproj
+++ b/src/LayTea.Tool/LayTea.Tool.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="LondonLife/*.txt" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../LayTea/LayTea.csproj" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>

--- a/src/LayTea.Tool/LondonLife/CommandLine.cs
+++ b/src/LayTea.Tool/LondonLife/CommandLine.cs
@@ -35,18 +35,20 @@ namespace SceneGate.Games.ProfessorLayton.Tool.LondonLife
         {
             var exportLondonLife = new Command("export-text", "Export the text") {
                 new Option<string>("--input", "the game file", ArgumentArity.ExactlyOne),
+                new Option<string>("--table", "optional path to the table file", ArgumentArity.ZeroOrOne),
                 new Option<LondonLifeTextFormat>("--format", "the format of the input file", ArgumentArity.ExactlyOne),
                 new Option<string>("--output", "the output folder for the text files", ArgumentArity.ExactlyOne),
             };
-            exportLondonLife.Handler = CommandHandler.Create<string, LondonLifeTextFormat, string>(TextCommands.Export);
+            exportLondonLife.Handler = CommandHandler.Create<string, string, LondonLifeTextFormat, string>(TextCommands.Export);
 
             var importLondonLife = new Command("import-text", "Import the text") {
                 new Option<string>("--input", "the input folder with the text files", ArgumentArity.ExactlyOne),
+                new Option<string>("--table", "optional path to the table file", ArgumentArity.ZeroOrOne),
                 new Option<string>("--original-darc", "the original ll_common.darc file if the output format is CommonDarc", ArgumentArity.ZeroOrOne),
                 new Option<string>("--output", "the new game file", ArgumentArity.ExactlyOne),
                 new Option<LondonLifeTextFormat>("--format", "the format of the output file", ArgumentArity.ExactlyOne),
             };
-            importLondonLife.Handler = CommandHandler.Create<string, string, string, LondonLifeTextFormat>(TextCommands.Import);
+            importLondonLife.Handler = CommandHandler.Create<string, string, string, string, LondonLifeTextFormat>(TextCommands.Import);
 
             return new Command("londonlife", "Professor Layton London Life (US only)") {
                 exportLondonLife,

--- a/src/LayTea.Tool/LondonLife/table_eur.txt
+++ b/src/LayTea.Tool/LondonLife/table_eur.txt
@@ -1,0 +1,100 @@
+# This is the original US font table plus some modifications to adapt it for
+# other Latin-1 languages.
+
+# Several texts use these char replacement for button and gender symbols
+# We shouldn't re-arrange as the original text already use these code-points.
+# Font 6 has the button symbols shifted 1 but it looks like a bug.
+¤=Ⓐ
+À=Ⓑ
+Á=Ⓧ
+Â=Ⓨ
+¸=♂
+¹=♀
+
+# The rest of original replacements are only used in corrupted "ban names" and the keyword
+# so we take the freedom to arrange all chars we don't plan to use to include all our European chars.
+# We need to map the characters in the function range: ðñòóôõö÷øùúûüýþÿ
+# and the three characters replaced for the button symbols: ÀÁÂ
+# We also unmap some European symbols needed like: ªº«»
+# We keep symbols as the original game for fancy player names.
+
+# Move to their correct place existing characters.
+\=\
+¥=¥
+×=×
+
+# Unmap symbols required
+»=»
+«=«
+ª=ª
+º=º
+
+# Rearrange already mapped but needed chars
+§=À
+¨=Á
+©=Â
+
+# European chars in the function range
+¬=ñ
+®=ò
+¯=ó
+°=ô
+±=õ
+²=ö
+³=ø
+µ=ù
+¶=ú
+·=û
+¼=ü
+½=ÿ
+
+# Not mapped as non-planned translations into languages using them
+# =ð
+# =ý
+# =þ
+
+# Keep cool symbols
+´=÷
+¾=♪
+`=☆
+~=★
+
+# Keep ellipsis since it's cool
+¦=…
+
+# Keep some symbols just in case
+¢=¢
+£=£
+
+# Free replacements characters with their original font mapping
+#~=~ # map
+#`=` # map
+#\=¥ # rearrange
+#¢=  # reserved just in case
+#£=  # reserved just in case
+# Code-point for button A above
+#¥=  # rearrange
+#¦=… # keep
+#§=× # map
+#¨=÷ # map
+#©=∞ # map
+#ª=♭ # keep
+#«=♪ # keep
+#¬=\ # map
+#®=☆ # map
+#¯=○ # map
+#°=△ # map
+#±=□ # map
+#²=「 # map
+#³=」 # map
+#´=『 # map
+#µ=』 # map
+#¶=【 # map
+#·=】 # map
+# Code-points already take for gender symbols at the top
+#º=★ # keep
+#»=● # keep
+#¼=▲ # map
+#½=■ # map
+#¾=  # map
+#×=  # keep

--- a/src/LayTea/Texts/LondonLife/MessageCollection2Binary.cs
+++ b/src/LayTea/Texts/LondonLife/MessageCollection2Binary.cs
@@ -83,16 +83,20 @@ namespace SceneGate.Games.ProfessorLayton.Texts.LondonLife
 
         private void WriteText(DataWriter writer, MessageRawText text)
         {
-            if (text.Text[0] >= FirstFunction) {
-                writer.Write(BlockPadding);
-            }
-
             foreach (char ch in text.Text) {
                 if (ch == '\n') {
                     writer.WritePadding(BlockPadding, 4);
                     writer.Write(NewLineId);
                     writer.Write((ushort)0x02); // func length is only this field
                 } else {
+                    // Make sure that if we write a char in the function range
+                    // and it's the beginning of a block, we have the escape token.
+                    // Theoretically this is possible and the original MSG.BIN use it
+                    // but in practice, in most script parts the game crashes anyway.
+                    if (ch >= FirstFunction && ((writer.Stream.Position % 4) == 0)) {
+                        writer.Write(BlockPadding);
+                    }
+
                     // Text is Latin-1, we need to convert to C# char (UTF-16).
                     // Latin-1 match the range of UTF-16 so casting is fast.
                     writer.Write((byte)ch);


### PR DESCRIPTION
### Description

Implement in the CLI the support to export and import texts with a custom table for London Life.
Add a table for EUR translations (require changes in the fonts).
Also fix an issue with the message file and special chars.

### Example

Use the argument `--table` to specify the path to the table file.
