### PR TITLE
Publish preview NuGets in Azure DevOps

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.201'
+  NET_SDK: '5.0.300'
 
 jobs:
   build_main:
@@ -33,7 +33,7 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.407'
+          dotnet-version: '3.1.409'
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -82,7 +82,7 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.407'
+          dotnet-version: '3.1.409'
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -98,6 +98,9 @@ jobs:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     needs: [ "build_main", "build_sec" ]
     runs-on: ubuntu-latest
+    env:
+      # Needed only for Azure DevOps Artifacts due to its weird auth method.
+      PREVIEW_NUGET_FEED: 'https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json'
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -117,14 +120,20 @@ jobs:
       - name: "Setup .NET Core 3.1 for Cake dependencies"
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.407'
+          dotnet-version: '3.1.409'
 
       - name: "Install build tools"
         run: dotnet tool restore
+
+      # Weird way to authenticate in Azure DevOps Artifacts
+      # Then, we need to setup VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
+      - name: "Install Azure Artifacts Credential Provider"
+        run: wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash
 
       - name: "Publish artifacts"
         run: dotnet cake --target=Push-Artifacts --verbosity=diagnostic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          STABLE_NUGET_FEED_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PREVIEW_NUGET_FEED_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STABLE_NUGET_FEED_TOKEN: ${{ secrets.STABLE_NUGET_FEED_TOKEN }}
+          PREVIEW_NUGET_FEED_TOKEN: "az" # Dummy, auth via below env var
+          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint":"${{ env.PREVIEW_NUGET_FEED }}", "username":"", "password":"${{ secrets.PREVIEW_NUGET_FEED_TOKEN }}"}]}'

--- a/build.cake
+++ b/build.cake
@@ -8,8 +8,7 @@ Task("Define-Project")
     info.AddApplicationProjects("LayTea.Tool");
     info.AddTestProjects("LayTea.Tests");
 
-    info.PreviewNuGetFeed = "https://nuget.pkg.github.com/pleonex/index.json";
-    info.StableNuGetFeed = "https://nuget.pkg.github.com/pleonex/index.json";
+    info.PreviewNuGetFeed = "https://pkgs.dev.azure.com/SceneGate/SceneGate/_packaging/SceneGate-Preview/nuget/v3/index.json";
 
     // We can't force code coverage as it requires game files
     info.CoverageTarget = 0;


### PR DESCRIPTION
### Description

GitHub still requires stupid authentication to get a NuGet package from its repository. Switching to Azure DevOps.
