### PR TITLE
Define default values to initialize converters

### DIFF
--- a/src/LayTea.Tests/Texts/LondonLife/MessageCollection2PoContainerTests.cs
+++ b/src/LayTea.Tests/Texts/LondonLife/MessageCollection2PoContainerTests.cs
@@ -37,11 +37,11 @@ namespace SceneGate.Games.ProfessorLayton.Tests.Texts.LondonLife
         }
 
         [Test]
-        public void MissingInitializerThrows()
+        public void MissingInitializerDoesNotThrow()
         {
             var messages = new MessageCollection();
             var converter = new MessageCollection2PoContainer();
-            Assert.That(() => converter.Convert(messages), Throws.InvalidOperationException);
+            Assert.That(() => converter.Convert(messages), Throws.Nothing);
         }
 
         [Test]

--- a/src/LayTea.Tests/Texts/PoTableReplacerTests.cs
+++ b/src/LayTea.Tests/Texts/PoTableReplacerTests.cs
@@ -34,10 +34,10 @@ namespace SceneGate.Games.ProfessorLayton.Tests.Texts
         }
 
         [Test]
-        public void ThrowIfNotInitialized()
+        public void DoesNotThrowIfNotInitialized()
         {
             Po po = new Po();
-            Assert.That(() => new PoTableReplacer().Convert(po), Throws.InvalidOperationException);
+            Assert.That(() => new PoTableReplacer().Convert(po), Throws.Nothing);
         }
 
         [Test]

--- a/src/LayTea/Texts/LondonLife/MessageCollection2PoContainer.cs
+++ b/src/LayTea/Texts/LondonLife/MessageCollection2PoContainer.cs
@@ -39,6 +39,17 @@ namespace SceneGate.Games.ProfessorLayton.Texts.LondonLife
         private MessageContextProvider contextProvider;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="MessageCollection2PoContainer" /> class.
+        /// </summary>
+        /// <remarks>
+        /// By default uses the USA region. Call <see cref="Initialize(LondonLifeRegion)" /> to change the region.
+        /// </remarks>
+        public MessageCollection2PoContainer()
+        {
+            contextProvider = new MessageContextProvider(LondonLifeRegion.Usa);
+        }
+
+        /// <summary>
         /// Initializes the converter with the game region.
         /// </summary>
         /// <param name="parameters">The game region.</param>
@@ -56,8 +67,6 @@ namespace SceneGate.Games.ProfessorLayton.Texts.LondonLife
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-            if (contextProvider == null)
-                throw new InvalidOperationException("Missing initialization");
 
             var container = new NodeContainerFormat();
 

--- a/src/LayTea/Texts/PoTableReplacer.cs
+++ b/src/LayTea/Texts/PoTableReplacer.cs
@@ -32,6 +32,21 @@ namespace SceneGate.Games.ProfessorLayton.Texts
         private PoTableReplacerParams parameters;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="PoTableReplacer" /> class.
+        /// </summary>
+        /// <remarks>
+        /// By default it does not apply any replacement. Call <see cref="Initialize(PoTableReplacerParams)" />
+        /// to specify the replacements.
+        /// </remarks>
+        public PoTableReplacer()
+        {
+            parameters = new PoTableReplacerParams {
+                Replacer = new Replacer(),
+                TransformForward = true,
+            };
+        }
+
+        /// <summary>
         /// Initializes the converter.
         /// </summary>
         /// <param name="parameters">The converter parameters.</param>
@@ -49,8 +64,6 @@ namespace SceneGate.Games.ProfessorLayton.Texts
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
-            if (parameters == null)
-                throw new InvalidOperationException("Missing initialization");
 
             foreach (var entry in source.Entries) {
                 if (parameters.TransformForward) {


### PR DESCRIPTION
### Description

In order to ease the use of the converter, this PR provides default common values for converters that requires initialization.